### PR TITLE
Fewer steps for deleteAfterTimeout

### DIFF
--- a/dinteractions_Paginator/_Paginator.py
+++ b/dinteractions_Paginator/_Paginator.py
@@ -148,7 +148,11 @@ async def Paginator(
             await button_context.defer(edit_origin=True)
         except TimeoutError:
             tmt = False
-            if disableAfterTimeout == True:
+            if deleteAfterTimeout == True:
+                await msg.edit(
+                    components=None
+                )
+            elif disableAfterTimeout == True:
                 selectControls["components"][0][
                     "disabled"
                 ] = True
@@ -159,11 +163,6 @@ async def Paginator(
                 await msg.edit(
                     components=components
                 )
-            if deleteAfterTimeout == True:
-                await msg.edit(
-                    components=None
-                )
-
         else:
             # Handling first button
             if button_context.component_id == f"{bid}-first" and index > 0:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md","r",encoding="utf-8") as fh:
 
 setup(
     name="dinteractions_Paginator",
-    version="1.1.3",
+    version="1.1.4",
     description="Unofficial discord-interactions multi page embed handler",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR removes the unnecessary step of disabling the components before deleting them.