### PR TITLE
Sending files and content only paginator

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,12 +158,12 @@ bot.run("token")
       <br>NOTE: if one of the latter 3 are used, there will always be a `This interaction failed` even though it was a
       success, due to no context to respond to
 
-- `pages` - `List[discord.Embed]`: A list of embeds to be paginated
-
 ------------------------------
 
 ### <a name="opt"></a> Optional:
 
+- `pages` - `Optional[List[discord.Embed]]`: the list of embeds to be paginated, defaults to `None` and paginates `content` instead
+  <br>NOTE: `content` must be a list for paginating without `pages`!
 - `content` - `Optional[Union[str, List[str]]]`: the content of the message to send, defaults to `None`
 - `files` - `Optional[Union[discord.File, List[discord.File]]]`: files to send, defaults to `None`
 - `hidden` - `Optional[bool]`: if you want the paginator to be hidden, default `False`

--- a/README.md
+++ b/README.md
@@ -1,23 +1,27 @@
 # dinteractions-Paginator
+
 Unofficial discord-interactions multi-page embed handler
 
 [![Discord](https://img.shields.io/discord/859508565101248582?color=blue&label=discord&style=for-the-badge)](https://discord.gg/UYCaSsMewk) [![PyPI - Downloads](https://img.shields.io/pypi/dm/dinteractions-Paginator?color=blue&style=for-the-badge)](https://pypi.org/project/dinteractions-Paginator/)
 
 ## Table of Contents
+
 (Only works in the [GitHub](https://github.com/JUGADOR123/dinteractions-Paginator/) for some reason)
+
 - [Features](#feats)
 - [Installation](#install)
 - [Dependencies](#dep)
 - [Examples](#examples)
-  - [Example GIF:](#gif)
-  - [Slash command:](#slash)
-  - [Normal command:](#normal)
-    - [Note](#note)
+    - [Example GIF:](#gif)
+    - [Slash command:](#slash)
+    - [Normal command:](#normal)
+        - [Note](#note)
 - [Paginator](#paginator)
 - [TimedOut](#timed)
 - [Credits](#credits)
 
 ## <a name="feats"></a> Features
+
 - Message per embed or persistent message
 - Index select that can be turned on/off
 - Select labels are generated based on embed's title
@@ -26,11 +30,13 @@ Unofficial discord-interactions multi-page embed handler
 - Custom buttons
 
 ### Join our [Discord server](https://discord.gg/UYCaSsMewk)!
+
 - Try out all the possible combinations of the paginator with `/example1` and `/example2`,
 - Ask some questions,
 - And give us feedback and suggestions!
 
 ### Wanna contribute?
+
 - Make an issue to:
     - say what feature you want to be added
     - file a bug report
@@ -40,22 +46,28 @@ Unofficial discord-interactions multi-page embed handler
 - Make sure you use the issue/PR template!
 
 ## <a name="install"></a> Installation
+
 ```
 pip install -U dinteractions-Paginator
 ```
 
 ### <a name="dep"></a> Dependencies
+
 - [discord.py](https://pypi.org/project/discord.py/) (version 1.7.3)
 - [discord-py-interactions](https://pypi.org/project/discord-py-interactions/) (version 3.0.2)
 
 ## <a name="examples"></a> Examples:
-These simple examples show how to easily create interactive, multiple page embeds that anyone can interact with that automatically deactivate after 60 seconds of inactivity:
+
+These simple examples show how to easily create interactive, multiple page embeds that anyone can interact with that
+automatically deactivate after 60 seconds of inactivity:
 
 ### <a name="gif"></a> Example GIF:
+
 Paginator with select:<br>
 <img src="https://cdn.discordapp.com/attachments/871853650568417310/882017626266697758/MDTxhoscwG.gif"></img>
 
 ### <a name="slash"></a> Slash command:
+
 ```py
 import discord
 from discord.ext import commands
@@ -65,9 +77,11 @@ from dinteractions_Paginator import Paginator
 bot = commands.Bot(command_prefix="/")
 slash = SlashCommand(bot, sync_commands=True)
 
+
 @bot.event
 async def on_ready():
     print(f"Logged in as {bot.user}!")
+
 
 @slash.slash(name="embeds")
 async def embeds(ctx: SlashContext):
@@ -80,10 +94,12 @@ async def embeds(ctx: SlashContext):
 
     await Paginator(bot=bot, ctx=ctx, pages=pages, content=["1", "2", "3", "4", "5"], timeout=60).run()
 
+
 bot.run("token")
 ```
 
 ### <a name="normal"></a> Normal command:
+
 ```py
 import discord
 from discord.ext import commands
@@ -93,9 +109,11 @@ from dinteractions_Paginator import Paginator
 bot = commands.Bot(command_prefix="/")
 slash = SlashCommand(bot)
 
+
 @bot.event
 async def on_ready():
     print(f"Logged in as {bot.user}!")
+
 
 @bot.command()
 async def embeds(ctx):
@@ -108,8 +126,10 @@ async def embeds(ctx):
 
     await Paginator(bot=bot, ctx=ctx, pages=pages, content=["1", "2", "3", "4", "5"], timeout=60).run()
 
+
 bot.run("token")
 ```
+
 #### <a name="note"></a> **NOTE: `slash = SlashCommand(bot)` required to override `bot`**
 
 ## <a name="paginator"></a> *class* Paginator
@@ -118,50 +138,64 @@ bot.run("token")
 
 - [Required](#req)
 - [Optional](#opt)
-  - [Time](#time)
-  - [What to use](#what)
-  - [Labels](#labels)
-  - [Emojis](#emojis)
-  - [Styles](#styles)
+    - [Time](#time)
+    - [What to use](#what)
+    - [Labels](#labels)
+    - [Emojis](#emojis)
+    - [Styles](#styles)
 - [Returns](#returns)
 - [customActionRow](#howtocustom)
-  - [Example code](#customcode)
-  - [Example GIF](#customgif)
-  - [Template](#customtemplate)
+    - [Example code](#customcode)
+    - [Example GIF](#customgif)
+    - [Template](#customtemplate)
 
 ### <a name="req"></a> Required:
+
 - `bot` - `commands.Bot`: The bot variable, `commands.Bot` is required
-- `ctx` - `Union[SlashContext, commands.Context, ComponentContext, MenuContext, discord.channel.TextChannel, discord.User, discord.Member]`: The context of a command.
-<br>NOTE: if one of the latter 3 are used, there will always be a `This interaction failed` even though it was a success, due to no context to respond to
+- `ctx`
+    - `Union[SlashContext, commands.Context, ComponentContext, MenuContext, discord.channel.TextChannel, discord.User, discord.Member]`:
+      The context of a command.
+      <br>NOTE: if one of the latter 3 are used, there will always be a `This interaction failed` even though it was a
+      success, due to no context to respond to
 
 - `pages` - `List[discord.Embed]`: A list of embeds to be paginated
 
 ------------------------------
 
 ### <a name="opt"></a> Optional:
+
 - `content` - `Optional[Union[str, List[str]]]`: the content of the message to send, defaults to `None`
+- `files` - `Optional[Union[discord.File, List[discord.File]]]`: files to send, defaults to `None`
 - `hidden` - `Optional[bool]`: if you want the paginator to be hidden, default `False`
 - `authorOnly` - `Optional[bool]`: if you want the paginator to work for the author only, default is `False`
-- `onlyFor` - `Optional[Union[discord.User, discord.Role, List[Union[discord.User, discord.Role]]]]`: components only for specified user(s) or role(s)
+- `onlyFor` - `Optional[Union[discord.User, discord.Role, List[Union[discord.User, discord.Role]]]]`: components only
+  for specified user(s) or role(s)
 - `dm` - `Optional[bool]`: if you want the paginator to be DM'ed, default `False`
-- `customActionRow` - `Optional[List[Union[dict, Callable]]]`: a custom action row, see [this](#howtocustom) for more info, defaults to `None`
+- `customActionRow` - `Optional[List[Union[dict, Callable]]]`: a custom action row, see [this](#howtocustom) for more
+  info, defaults to `None`
 
 #### <a name="time"></a> Time:
-- `timeout` - `Optional[int]`: deactivates paginator after inactivity if enabled, defaults to `None` (meaning no timeout)
+
+- `timeout` - `Optional[int]`: deactivates paginator after inactivity if enabled, defaults to `None` (meaning no
+  timeout)
 - `disableAfterTimeout` - `Optional[bool]`: disable components after `timeout`, default `True`
 - `deleteAfterTimeout` - `Opti onal[bool]`: delete components after `timeout`, default `False`
 
 #### <a name="what"></a> What to use:
+
 - `useButtons` - `Optional[bool]`: uses buttons, default is `True`
 - `useSelect` - `Optional[bool]`: uses a select, default is `True`
-- `useIndexButton` - `Optional[bool]`: uses the index button, default is `False` and stays `False` if `useButtons` is also `False`
+- `useIndexButton` - `Optional[bool]`: uses the index button, default is `False` and stays `False` if `useButtons` is
+  also `False`
 - `useLinkButton` - `Optional[bool]`: uses the link button
 - `useQuitButton` - `Optional[bool]`: quit button to end the paginator, default `False`
 - `useFirstLast` - `Optional[bool]`: uses the first and last buttons, default `True`
 - `useOverflow` - `Optional[bool]`: uses the overflow action row if there are too many buttons, default `True`
-- `useNotYours` - `Optional[bool]`: sends an ephemeral (hidden) message if the paginator is not yours (see authorOnly or onlyFor), default `True`
+- `useNotYours` - `Optional[bool]`: sends an ephemeral (hidden) message if the paginator is not yours (see authorOnly or
+  onlyFor), default `True`
 
 #### <a name="labels"></a> Labels:
+
 - `firstLabel` - `Optional[str]`: The label of the button used to go to the first page, defaults to `""`
 - `prevLabel` - `Optional[str]`: The label of the button used to go to the previous page, defaults to `""`
 - `indexLabel` - `Optional[str]`: The label of the index button, defaults to `"Page"`
@@ -173,25 +207,40 @@ bot.run("token")
 - `quitButtonLabel` - `Optional[str]`: The label of the quit button, default `"Quit"`
 
 #### <a name="emojis"></a> Emojis:
-- `firstEmoji` - `Optional[Union[discord.emoji.Emoji, discord.partial_emoji.PartialEmoji, dict, str]`: emoji of the button used to go to the first page, defaults to `"⏮️"`
-- `prevEmoji` - `Optional[Union[discord.emoji.Emoji, discord.partial_emoji.PartialEmoji, dict, str]`: emoji of the button used to go to the previous page, defaults to `"◀"`
-- `nextEmoji` - `Optional[Union[discord.emoji.Emoji, discord.partial_emoji.PartialEmoji, dict, str]`: emoji of the button used to go to the next page, defaults to `"▶"`
-- `lastEmoji` - `Optional[Union[discord.emoji.Emoji, discord.partial_emoji.PartialEmoji, dict, str]`: emoji of the button used to go to the last page, defaults to `"⏭️"`
-- `customButtonEmoji` - `Optional[Union[discord.emoji.Emoji, discord.partial_emoji.PartialEmoji, dict, str]`: emoji of the custom disabled button, defaults to `None`
-- `quitButtonEmoji` - `Optional[Union[discord.emoji.Emoji, discord.partial_emoji.PartialEmoji, dict, str]`: emoji of the quit button, defaults to `None`
+
+- `firstEmoji` - `Optional[Union[discord.emoji.Emoji, discord.partial_emoji.PartialEmoji, dict, str]`: emoji of the
+  button used to go to the first page, defaults to `"⏮️"`
+- `prevEmoji` - `Optional[Union[discord.emoji.Emoji, discord.partial_emoji.PartialEmoji, dict, str]`: emoji of the
+  button used to go to the previous page, defaults to `"◀"`
+- `nextEmoji` - `Optional[Union[discord.emoji.Emoji, discord.partial_emoji.PartialEmoji, dict, str]`: emoji of the
+  button used to go to the next page, defaults to `"▶"`
+- `lastEmoji` - `Optional[Union[discord.emoji.Emoji, discord.partial_emoji.PartialEmoji, dict, str]`: emoji of the
+  button used to go to the last page, defaults to `"⏭️"`
+- `customButtonEmoji` - `Optional[Union[discord.emoji.Emoji, discord.partial_emoji.PartialEmoji, dict, str]`: emoji of
+  the custom disabled button, defaults to `None`
+- `quitButtonEmoji` - `Optional[Union[discord.emoji.Emoji, discord.partial_emoji.PartialEmoji, dict, str]`: emoji of the
+  quit button, defaults to `None`
 
 #### <a name="styles"></a> Styles (the colo[u]r of the buttons):
-- `firstStyle` - `Optional[Union[ButtonStyle, int]]`: the style of button (`ButtonStyle` or `int`) for the first button, defaults to `1` (`ButtonStyle.blue`)
-- `prevStyle` - `Optional[Union[ButtonStyle, int]]`: the style of button (`ButtonStyle` or `int`) for the previous button, defaults to `1` (`ButtonStyle.blue`)
-- `indexStyle` - `Optional[Union[ButtonStyle, int]]`: the style of button (`ButtonStyle` or `int`) for the index button, defaults to `3` (`ButtonStyle.green`)
-- `nextStyle` - `Optional[Union[ButtonStyle, int]]`: the style of button (`ButtonStyle` or `int`) for the next button, defaults to `1` (`ButtonStyle.blue`)
-- `lastStyle` - `Optional[Union[ButtonStyle, int]]`: the style of button (`ButtonStyle` or `int`) for the last button, defaults to `1` (`ButtonStyle.blue`)
-- `customButtonStyle` - `Optional[Union[ButtonStyle, int]]`: the style of button (`ButtonStyle` or `int`) for the custom disabled button, defaults to `2` (`ButtonStyle.gray`)
-- `quitButtonStyle` - `Optional[Union[ButtonStyle, int]]`: the style of button (`ButtonStyle` or `int`) for the quit button, defaults to `4` (`ButtonStyle.red`)
+
+- `firstStyle` - `Optional[Union[ButtonStyle, int]]`: the style of button (`ButtonStyle` or `int`) for the first button,
+  defaults to `1` (`ButtonStyle.blue`)
+- `prevStyle` - `Optional[Union[ButtonStyle, int]]`: the style of button (`ButtonStyle` or `int`) for the previous
+  button, defaults to `1` (`ButtonStyle.blue`)
+- `indexStyle` - `Optional[Union[ButtonStyle, int]]`: the style of button (`ButtonStyle` or `int`) for the index button,
+  defaults to `3` (`ButtonStyle.green`)
+- `nextStyle` - `Optional[Union[ButtonStyle, int]]`: the style of button (`ButtonStyle` or `int`) for the next button,
+  defaults to `1` (`ButtonStyle.blue`)
+- `lastStyle` - `Optional[Union[ButtonStyle, int]]`: the style of button (`ButtonStyle` or `int`) for the last button,
+  defaults to `1` (`ButtonStyle.blue`)
+- `customButtonStyle` - `Optional[Union[ButtonStyle, int]]`: the style of button (`ButtonStyle` or `int`) for the custom
+  disabled button, defaults to `2` (`ButtonStyle.gray`)
+- `quitButtonStyle` - `Optional[Union[ButtonStyle, int]]`: the style of button (`ButtonStyle` or `int`) for the quit
+  button, defaults to `4` (`ButtonStyle.red`)
 
 ### <a name="returns"></a> Returns
-[*class* TimedOut](#timed)
 
+[*class* TimedOut](#timed)
 
 ### <a name="howtocustom"></a> More info on `customActionRow`:
 
@@ -234,32 +283,36 @@ async def _custom_action_row(ctx: SlashContext):
         ],  # Note that custom_function is not called
     ).run()
 ```
+
 The code above runs a normal paginator, with 1 extra action row at the bottom!
 
 #### <a name="customgif"></a> Example GIF:
 
 <img src="https://cdn.discordapp.com/attachments/871853650568417310/884243305947340820/pDQZld6v19.gif"></img>
 
-You can access all of the attributes of [*class* Paginator](#paginator) with `self`, such as the original command's context (`self.ctx`), the bot variable (`self.bot`), and other things that you passed into it!
+You can access all of the attributes of [*class* Paginator](#paginator) with `self`, such as the original command's
+context (`self.ctx`), the bot variable (`self.bot`), and other things that you passed into it!
 
 #### <a name="customtemplate"></a> Template:
 
 ```py
 # <-- Your decorator here
-    # ...
-    buttons = [
-        create_button(style=3, label="A Green Button"),
-        ... # Your buttons
-    ]
-    custom_action_row = create_actionrow(*buttons)
+# ...
+buttons = [
+    create_button(style=3, label="A Green Button"),
+    ...  # Your buttons
+]
+custom_action_row = create_actionrow(*buttons)
 
-    # Function:
-    async def custom_function(self, button_ctx):
-        pass  # Your code for the action row here
-        # You could check for each button and decide
-        # what to do
 
-    await Paginator(..., customActionRow=[custom_action_row, custom_function]).run()
+# Function:
+async def custom_function(self, button_ctx):
+    pass  # Your code for the action row here
+    # You could check for each button and decide
+    # what to do
+
+
+await Paginator(..., customActionRow=[custom_action_row, custom_function]).run()
 ```
 
 ------------------------------
@@ -267,6 +320,7 @@ You can access all of the attributes of [*class* Paginator](#paginator) with `se
 ## <a name="timed"></a> *class* TimedOut
 
 ### <a name="attrs"></a> Attributes
+
 - `ctx` - `Union[commands.Context, SlashContext]`: The original context
 - `buttonContext` - `ComponentContext`: The context for the paginator's components
 - `timeTaken` - `int`: How long in seconds that user(s) used the paginator before the timeout
@@ -278,6 +332,7 @@ You can access all of the attributes of [*class* Paginator](#paginator) with `se
 -------------------------------
 
 ## <a name="credits"></a> Credits
+
 - Contributors of [discord-interactions](https://pypi.org/project/discord-py-slash-command/)
     - [GitHub](https://github.com/discord-py-slash-commands/discord-py-interactions)
     - [Discord server](https://discord.gg/KkgMBVuEkx)

--- a/dinteractions_Paginator/_Paginator.py
+++ b/dinteractions_Paginator/_Paginator.py
@@ -17,31 +17,25 @@ from discord_slash.utils.manage_components import (
     wait_for_component,
 )
 
-from .errors import (
-    BadButtons,
-    BadOnly,
-    IncorrectDataType,
-    TooManyButtons,
-    TooManyFiles
-)
+from .errors import BadButtons, BadOnly, IncorrectDataType, TooManyButtons, TooManyFiles
 
 
 class TimedOut:
     def __init__(
-            self,
-            ctx: Union[
-                InteractionContext,
-                Context,
-                TextChannel,
-                User,
-                Member,
-            ],
-            buttonContext: ComponentContext,
-            timeTaken: int,
-            lastContent: str,
-            lastEmbed: Embed,
-            successfulUsers: List[User],
-            failedUsers: List[User],
+        self,
+        ctx: Union[
+            InteractionContext,
+            Context,
+            TextChannel,
+            User,
+            Member,
+        ],
+        buttonContext: ComponentContext,
+        timeTaken: int,
+        lastContent: str,
+        lastEmbed: Embed,
+        successfulUsers: List[User],
+        failedUsers: List[User],
     ):
         self.ctx = ctx
         self.buttonContext = buttonContext
@@ -54,62 +48,62 @@ class TimedOut:
 
 class Paginator:
     def __init__(
-            self,
-            bot: Union[AutoShardedBot, Bot],
-            ctx: Union[
-                InteractionContext,
-                Context,
-                TextChannel,
+        self,
+        bot: Union[AutoShardedBot, Bot],
+        ctx: Union[
+            InteractionContext,
+            Context,
+            TextChannel,
+            User,
+            Member,
+        ],
+        pages: List[Embed],
+        content: Optional[Union[str, List[str]]] = None,
+        files: Optional[Union[File, List[File]]] = None,
+        hidden: Optional[bool] = False,
+        authorOnly: Optional[bool] = False,
+        onlyFor: Optional[
+            Union[
                 User,
-                Member,
-            ],
-            pages: List[Embed],
-            content: Optional[Union[str, List[str]]] = None,
-            files: Optional[Union[File, List[File]]] = None,
-            hidden: Optional[bool] = False,
-            authorOnly: Optional[bool] = False,
-            onlyFor: Optional[
-                Union[
-                    User,
-                    Role,
-                    List[Union[User, Role]],
-                ]
-            ] = None,
-            dm: Optional[bool] = False,
-            customActionRow: Optional[List[Union[dict, Callable]]] = None,
-            timeout: Optional[int] = None,
-            disableAfterTimeout: Optional[bool] = True,
-            deleteAfterTimeout: Optional[bool] = False,
-            useSelect: Optional[bool] = True,
-            useButtons: Optional[bool] = True,
-            useIndexButton: Optional[bool] = None,
-            useLinkButton: Optional[bool] = False,
-            useQuitButton: Optional[bool] = False,
-            useFirstLast: Optional[bool] = True,
-            useOverflow: Optional[bool] = True,
-            useNotYours: Optional[bool] = True,
-            firstLabel: Optional[str] = "",
-            prevLabel: Optional[str] = "",
-            indexLabel: Optional[str] = "Page",
-            nextLabel: Optional[str] = "",
-            lastLabel: Optional[str] = "",
-            linkLabel: Optional[Union[str, List[str]]] = "",
-            linkURL: Optional[Union[str, List[str]]] = "",
-            customButtonLabel: Optional[str] = None,
-            quitButtonLabel: Optional[str] = "Quit",
-            firstEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = "⏮️",
-            prevEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = "◀",
-            nextEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = "▶",
-            lastEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = "⏭️",
-            customButtonEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = None,
-            quitButtonEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = None,
-            firstStyle: Optional[Union[ButtonStyle, int]] = 1,
-            prevStyle: Optional[Union[ButtonStyle, int]] = 1,
-            indexStyle: Optional[Union[ButtonStyle, int]] = 2,
-            nextStyle: Optional[Union[ButtonStyle, int]] = 1,
-            lastStyle: Optional[Union[ButtonStyle, int]] = 1,
-            customButtonStyle: Optional[Union[ButtonStyle, int]] = 2,
-            quitButtonStyle: Optional[Union[ButtonStyle, int]] = 4,
+                Role,
+                List[Union[User, Role]],
+            ]
+        ] = None,
+        dm: Optional[bool] = False,
+        customActionRow: Optional[List[Union[dict, Callable]]] = None,
+        timeout: Optional[int] = None,
+        disableAfterTimeout: Optional[bool] = True,
+        deleteAfterTimeout: Optional[bool] = False,
+        useSelect: Optional[bool] = True,
+        useButtons: Optional[bool] = True,
+        useIndexButton: Optional[bool] = None,
+        useLinkButton: Optional[bool] = False,
+        useQuitButton: Optional[bool] = False,
+        useFirstLast: Optional[bool] = True,
+        useOverflow: Optional[bool] = True,
+        useNotYours: Optional[bool] = True,
+        firstLabel: Optional[str] = "",
+        prevLabel: Optional[str] = "",
+        indexLabel: Optional[str] = "Page",
+        nextLabel: Optional[str] = "",
+        lastLabel: Optional[str] = "",
+        linkLabel: Optional[Union[str, List[str]]] = "",
+        linkURL: Optional[Union[str, List[str]]] = "",
+        customButtonLabel: Optional[str] = None,
+        quitButtonLabel: Optional[str] = "Quit",
+        firstEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = "⏮️",
+        prevEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = "◀",
+        nextEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = "▶",
+        lastEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = "⏭️",
+        customButtonEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = None,
+        quitButtonEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = None,
+        firstStyle: Optional[Union[ButtonStyle, int]] = 1,
+        prevStyle: Optional[Union[ButtonStyle, int]] = 1,
+        indexStyle: Optional[Union[ButtonStyle, int]] = 2,
+        nextStyle: Optional[Union[ButtonStyle, int]] = 1,
+        lastStyle: Optional[Union[ButtonStyle, int]] = 1,
+        customButtonStyle: Optional[Union[ButtonStyle, int]] = 2,
+        quitButtonStyle: Optional[Union[ButtonStyle, int]] = 4,
     ) -> None:
         # attributes:
         self.bot = bot
@@ -277,7 +271,7 @@ class Paginator:
                     content=self.content[0] if self.multiContent else self.content,
                     embed=self.pages[0],
                     components=self.components(),
-                    files=self.files
+                    files=self.files,
                 )
                 await self.ctx.send("Check your DMs!", hidden=True) if isinstance(
                     self.ctx, InteractionContext
@@ -287,7 +281,7 @@ class Paginator:
                     content=self.content[0] if self.multiContent else self.content,
                     embed=self.pages[0],
                     components=self.components(),
-                    files=self.files
+                    files=self.files,
                 )
             else:
                 raise IncorrectDataType(
@@ -302,14 +296,14 @@ class Paginator:
                     embed=self.pages[0],
                     components=self.components(),
                     hidden=self.hidden,
-                    files=self.files
+                    files=self.files,
                 )
                 if isinstance(self.ctx, InteractionContext)
                 else await self.ctx.send(
                     content=self.content[0] if self.multiContent else self.content,
                     embed=self.pages[0],
                     components=self.components(),
-                    files=self.files
+                    files=self.files,
                 )
             )
         # more useful variables:

--- a/dinteractions_Paginator/_Paginator.py
+++ b/dinteractions_Paginator/_Paginator.py
@@ -22,25 +22,26 @@ from .errors import (
     BadOnly,
     IncorrectDataType,
     TooManyButtons,
+    TooManyFiles
 )
 
 
 class TimedOut:
     def __init__(
-        self,
-        ctx: Union[
-            InteractionContext,
-            Context,
-            TextChannel,
-            User,
-            Member,
-        ],
-        buttonContext: ComponentContext,
-        timeTaken: int,
-        lastContent: str,
-        lastEmbed: Embed,
-        successfulUsers: List[User],
-        failedUsers: List[User],
+            self,
+            ctx: Union[
+                InteractionContext,
+                Context,
+                TextChannel,
+                User,
+                Member,
+            ],
+            buttonContext: ComponentContext,
+            timeTaken: int,
+            lastContent: str,
+            lastEmbed: Embed,
+            successfulUsers: List[User],
+            failedUsers: List[User],
     ):
         self.ctx = ctx
         self.buttonContext = buttonContext
@@ -53,69 +54,69 @@ class TimedOut:
 
 class Paginator:
     def __init__(
-        self,
-        bot: Union[AutoShardedBot, Bot],
-        ctx: Union[
-            InteractionContext,
-            Context,
-            TextChannel,
-            User,
-            Member,
-        ],
-        
-        pages: List[Embed],
-        content: Optional[Union[str, List[str]]] = None,
-        hidden: Optional[bool] = False,
-        authorOnly: Optional[bool] = False,
-        onlyFor: Optional[
-            Union[
+            self,
+            bot: Union[AutoShardedBot, Bot],
+            ctx: Union[
+                InteractionContext,
+                Context,
+                TextChannel,
                 User,
-                Role,
-                List[Union[User, Role]],
-            ]
-        ] = None,
-        files: Optional[File]= None,
-        dm: Optional[bool] = False,
-        customActionRow: Optional[List[Union[dict, Callable]]] = None,
-        timeout: Optional[int] = None,
-        disableAfterTimeout: Optional[bool] = True,
-        deleteAfterTimeout: Optional[bool] = False,
-        useSelect: Optional[bool] = True,
-        useButtons: Optional[bool] = True,
-        useIndexButton: Optional[bool] = None,
-        useLinkButton: Optional[bool] = False,
-        useQuitButton: Optional[bool] = False,
-        useFirstLast: Optional[bool] = True,
-        useOverflow: Optional[bool] = True,
-        useNotYours: Optional[bool] = True,
-        firstLabel: Optional[str] = "",
-        prevLabel: Optional[str] = "",
-        indexLabel: Optional[str] = "Page",
-        nextLabel: Optional[str] = "",
-        lastLabel: Optional[str] = "",
-        linkLabel: Optional[Union[str, List[str]]] = "",
-        linkURL: Optional[Union[str, List[str]]] = "",
-        customButtonLabel: Optional[str] = None,
-        quitButtonLabel: Optional[str] = "Quit",
-        firstEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = "⏮️",
-        prevEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = "◀",
-        nextEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = "▶",
-        lastEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = "⏭️",
-        customButtonEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = None,
-        quitButtonEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = None,
-        firstStyle: Optional[Union[ButtonStyle, int]] = 1,
-        prevStyle: Optional[Union[ButtonStyle, int]] = 1,
-        indexStyle: Optional[Union[ButtonStyle, int]] = 2,
-        nextStyle: Optional[Union[ButtonStyle, int]] = 1,
-        lastStyle: Optional[Union[ButtonStyle, int]] = 1,
-        customButtonStyle: Optional[Union[ButtonStyle, int]] = 2,
-        quitButtonStyle: Optional[Union[ButtonStyle, int]] = 4,
-    ) -> TimedOut:
+                Member,
+            ],
+            pages: List[Embed],
+            content: Optional[Union[str, List[str]]] = None,
+            files: Optional[Union[File, List[File]]] = None,
+            hidden: Optional[bool] = False,
+            authorOnly: Optional[bool] = False,
+            onlyFor: Optional[
+                Union[
+                    User,
+                    Role,
+                    List[Union[User, Role]],
+                ]
+            ] = None,
+            dm: Optional[bool] = False,
+            customActionRow: Optional[List[Union[dict, Callable]]] = None,
+            timeout: Optional[int] = None,
+            disableAfterTimeout: Optional[bool] = True,
+            deleteAfterTimeout: Optional[bool] = False,
+            useSelect: Optional[bool] = True,
+            useButtons: Optional[bool] = True,
+            useIndexButton: Optional[bool] = None,
+            useLinkButton: Optional[bool] = False,
+            useQuitButton: Optional[bool] = False,
+            useFirstLast: Optional[bool] = True,
+            useOverflow: Optional[bool] = True,
+            useNotYours: Optional[bool] = True,
+            firstLabel: Optional[str] = "",
+            prevLabel: Optional[str] = "",
+            indexLabel: Optional[str] = "Page",
+            nextLabel: Optional[str] = "",
+            lastLabel: Optional[str] = "",
+            linkLabel: Optional[Union[str, List[str]]] = "",
+            linkURL: Optional[Union[str, List[str]]] = "",
+            customButtonLabel: Optional[str] = None,
+            quitButtonLabel: Optional[str] = "Quit",
+            firstEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = "⏮️",
+            prevEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = "◀",
+            nextEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = "▶",
+            lastEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = "⏭️",
+            customButtonEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = None,
+            quitButtonEmoji: Optional[Union[Emoji, PartialEmoji, dict, str]] = None,
+            firstStyle: Optional[Union[ButtonStyle, int]] = 1,
+            prevStyle: Optional[Union[ButtonStyle, int]] = 1,
+            indexStyle: Optional[Union[ButtonStyle, int]] = 2,
+            nextStyle: Optional[Union[ButtonStyle, int]] = 1,
+            lastStyle: Optional[Union[ButtonStyle, int]] = 1,
+            customButtonStyle: Optional[Union[ButtonStyle, int]] = 2,
+            quitButtonStyle: Optional[Union[ButtonStyle, int]] = 4,
+    ) -> None:
         # attributes:
         self.bot = bot
         self.ctx = ctx
         self.pages = pages
         self.content = content
+        self.files = files if isinstance(files, (list, type(None))) else [files]
         self.hidden = hidden
         self.authorOnly = authorOnly
         self.onlyFor = onlyFor
@@ -138,7 +139,6 @@ class Paginator:
         self.emojis = [firstEmoji, prevEmoji, nextEmoji, lastEmoji]
         self.styles = [firstStyle, prevStyle, indexStyle, nextStyle, lastStyle]
         self.customActionRow = customActionRow
-        self.files=files
 
         # useful variables:
         self.top = len(self.pages)
@@ -165,9 +165,11 @@ class Paginator:
             (InteractionContext, Context, TextChannel, User, Member),
             "InteractionContext, commands.Context, discord.TextChannel, discord.User, or discord.Member",
         )
+        self.incdata("pages", self.pages, list, "List[discord.Embed]")
         self.incdata(
             "content", self.content, (list, str, type(None)), "str or list(str)"
         )
+        self.incdata("files", self.files, (list, type(None)), "List[discord.File]")
         self.incdata("hidden", self.hidden, bool, "bool")
         self.incdata("authorOnly", self.authorOnly, bool, "bool")
         self.incdata(
@@ -263,6 +265,8 @@ class Paginator:
             self.useSelect = False
             if self.useIndexButton is None:
                 self.useIndexButton = True
+        if len(self.files) > 10:
+            raise TooManyFiles
 
     # main:
     async def run(self) -> TimedOut:
@@ -298,6 +302,7 @@ class Paginator:
                     embed=self.pages[0],
                     components=self.components(),
                     hidden=self.hidden,
+                    files=self.files
                 )
                 if isinstance(self.ctx, InteractionContext)
                 else await self.ctx.send(
@@ -337,7 +342,6 @@ class Paginator:
                     self.index = int(buttonContext.selected_options[0])
                 # quit button:
                 elif buttonContext.custom_id == f"quit":
-                    tmt = False
                     end = time()
                     if self.deleteAfterTimeout and not self.hidden:
                         await buttonContext.edit_origin(components=None)
@@ -604,7 +608,7 @@ class Paginator:
             )
         )
 
-    # stamds for incorrect data (uses indincdata)
+    # stands for incorrect data (uses indincdata)
     def incdata(self, name, arg, sup, supstr) -> None:
         # stands for individual incdata (raises IncorrectDataType)
         def indincdata(name, arg, sup, supstr):
@@ -627,12 +631,7 @@ class Paginator:
         # checks if there are multiple args to be indincdata'ed:
         if isinstance(name, dict) and arg is None:
             for n in name:
-                indincdata(
-                    n,
-                    name[n],
-                    sup,
-                    supstr,
-                )
+                indincdata(n, name[n], sup, supstr)
         else:
             indincdata(name, arg, sup, supstr)
 

--- a/dinteractions_Paginator/_Paginator.py
+++ b/dinteractions_Paginator/_Paginator.py
@@ -2,7 +2,7 @@ from asyncio import TimeoutError, get_running_loop
 from time import time
 from typing import List, Optional, Union, Callable
 
-from discord import Embed, Emoji, Member, PartialEmoji, Role, User
+from discord import Embed, Emoji, Member, PartialEmoji, Role, User, File
 from discord.abc import User as userUser
 from discord.channel import TextChannel
 from discord.ext.commands import AutoShardedBot, Bot, Context
@@ -62,6 +62,7 @@ class Paginator:
             User,
             Member,
         ],
+        
         pages: List[Embed],
         content: Optional[Union[str, List[str]]] = None,
         hidden: Optional[bool] = False,
@@ -73,6 +74,7 @@ class Paginator:
                 List[Union[User, Role]],
             ]
         ] = None,
+        files: Optional[File]= None,
         dm: Optional[bool] = False,
         customActionRow: Optional[List[Union[dict, Callable]]] = None,
         timeout: Optional[int] = None,
@@ -136,6 +138,7 @@ class Paginator:
         self.emojis = [firstEmoji, prevEmoji, nextEmoji, lastEmoji]
         self.styles = [firstStyle, prevStyle, indexStyle, nextStyle, lastStyle]
         self.customActionRow = customActionRow
+        self.files=files
 
         # useful variables:
         self.top = len(self.pages)
@@ -270,6 +273,7 @@ class Paginator:
                     content=self.content[0] if self.multiContent else self.content,
                     embed=self.pages[0],
                     components=self.components(),
+                    files=self.files
                 )
                 await self.ctx.send("Check your DMs!", hidden=True) if isinstance(
                     self.ctx, InteractionContext
@@ -279,6 +283,7 @@ class Paginator:
                     content=self.content[0] if self.multiContent else self.content,
                     embed=self.pages[0],
                     components=self.components(),
+                    files=self.files
                 )
             else:
                 raise IncorrectDataType(
@@ -299,6 +304,7 @@ class Paginator:
                     content=self.content[0] if self.multiContent else self.content,
                     embed=self.pages[0],
                     components=self.components(),
+                    files=self.files
                 )
             )
         # more useful variables:

--- a/dinteractions_Paginator/errors.py
+++ b/dinteractions_Paginator/errors.py
@@ -19,6 +19,13 @@ class TooManyButtons(PaginatorError):
         )
 
 
+class TooManyFiles(PaginatorError):
+    def __init__(self):
+        super().__init__(
+            "Too many files! Max 10!"
+        )
+
+
 class PaginatorWarning(Warning):
     """Base class for warnings"""
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md","r",encoding="utf-8") as fh:
 
 setup(
     name="dinteractions_Paginator",
-    version="1.3.5",
+    version="1.3.6",
     description="Unofficial discord-interactions multi page embed handler",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## About this pull request

Sending files and content only paginator

## Changes

- Ability to add a file or a list of files to `files`
- Ability to not specify `pages`, which would paginate `content` instead
  - Make sure `content` is a list of strings for this to work!

## Checklist

- [x] I've used [black](https://pypi.org/project/black/) to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/JUGADOR123/dinteractions-Paginator/issues).
    - Issue:
- [x] This adds something new.
- [ ] There is/are breaking change(s).
- [x] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
